### PR TITLE
[Feature] Armazenar dados antigos

### DIFF
--- a/lib/mix/tasks/papertrail/install.ex
+++ b/lib/mix/tasks/papertrail/install.ex
@@ -21,6 +21,7 @@ defmodule Mix.Tasks.Papertrail.Install do
           add :item_type,    :string, null: false
           add :item_id,      :integer
           add :item_changes, :map, null: false
+          add :item_from,    :map
           add :originator_id, references(:users) # you can change :users to your own foreign key constraint
           add :origin,       :string, size: 50
           add :meta,         :map

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -15,7 +15,17 @@ defmodule PaperTrail do
   @doc """
   Inserts a record to the database with a related version insertion in one transaction
   """
-  def insert(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version]) do
+  def insert(
+        changeset,
+        options \\ [
+          origin: nil,
+          meta: nil,
+          originator: nil,
+          prefix: nil,
+          model_key: :model,
+          version_key: :version
+        ]
+      ) do
     PaperTrail.Multi.new()
     |> PaperTrail.Multi.insert(changeset, options)
     |> PaperTrail.Multi.commit()
@@ -24,7 +34,17 @@ defmodule PaperTrail do
   @doc """
   Same as insert/2 but returns only the model struct or raises if the changeset is invalid.
   """
-  def insert!(changeset, options \\ [origin: nil, meta: nil, originator: nil, prefix: nil, model_key: :model, version_key: :version]) do
+  def insert!(
+        changeset,
+        options \\ [
+          origin: nil,
+          meta: nil,
+          originator: nil,
+          prefix: nil,
+          model_key: :model,
+          version_key: :version
+        ]
+      ) do
     repo = RepoClient.repo()
 
     repo.transaction(fn ->
@@ -168,6 +188,7 @@ defmodule PaperTrail do
       item_type: get_item_type(changeset),
       item_id: get_model_id(changeset),
       item_changes: changeset.changes,
+      item_old: serialize(changeset.data),
       originator_id:
         case originator_ref do
           nil -> nil

--- a/lib/paper_trail.ex
+++ b/lib/paper_trail.ex
@@ -182,13 +182,18 @@ defmodule PaperTrail do
   defp make_version_struct(%{event: "update"}, changeset, options) do
     originator = PaperTrail.RepoClient.originator()
     originator_ref = options[originator[:name]] || options[:originator]
+    changed_keys = Map.keys(changeset.changes)
+
+    item_old =
+      Enum.filter(changeset.data, fn {key, _} -> key in changed_keys end)
+      |> Enum.into(%{})
 
     %Version{
       event: "update",
       item_type: get_item_type(changeset),
       item_id: get_model_id(changeset),
       item_changes: changeset.changes,
-      item_old: serialize(changeset.data),
+      item_old: item_old,
       originator_id:
         case originator_ref do
           nil -> nil

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -184,6 +184,7 @@ defmodule PaperTrail.Multi do
       item_type: get_item_type(changeset),
       item_id: get_model_id(changeset),
       item_changes: changeset.changes,
+      item_old: serialize(changeset.data),
       originator_id:
         case originator_ref do
           nil -> nil

--- a/lib/paper_trail/multi.ex
+++ b/lib/paper_trail/multi.ex
@@ -178,13 +178,18 @@ defmodule PaperTrail.Multi do
   defp make_version_struct(%{event: "update"} = match, changeset, options) do
     originator = PaperTrail.RepoClient.originator()
     originator_ref = options[originator[:name]] || options[:originator]
+    changed_keys = Map.keys(changeset.changes)
+
+    item_old =
+      Enum.filter(changeset.data, fn {key, _} -> key in changed_keys end)
+      |> Enum.into(%{})
 
     %Version{
       event: "update",
       item_type: get_item_type(changeset),
       item_id: get_model_id(changeset),
       item_changes: changeset.changes,
-      item_old: serialize(changeset.data),
+      item_old: item_old,
       originator_id:
         case originator_ref do
           nil -> nil

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -13,6 +13,7 @@ defmodule PaperTrail.Version do
     field(:item_type, :string)
     field(:item_id, Application.get_env(:paper_trail, :item_type, :integer))
     field(:item_changes, :map)
+    field(:item_old, :map)
     field(:originator_id, Application.get_env(:paper_trail, :originator_type, :integer))
 
     field(:origin, :string,
@@ -34,10 +35,12 @@ defmodule PaperTrail.Version do
     timestamps(updated_at: false)
   end
 
+  @required_fields ~w(event item_type item_id item_changes)a
+  @all_fields ~w(item_type item_id item_changes item_old origin originator_id meta)a
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, [:item_type, :item_id, :item_changes, :origin, :originator_id, :meta])
-    |> validate_required([:event, :item_type, :item_id, :item_changes])
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PaperTrail.Mixfile do
   def project do
     [
       app: :paper_trail,
-      version: "0.8.7",
+      version: "0.9.7",
       elixir: "~> 1.10",
       description: description(),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Mudanças:
- adicionado campo `item_old` que é a versão anterior dos dados
- `item_old` tem apenas os campos alterados (campos presentes em `item_changes`)
- agora um `update` pega o `data` do changeset e armazena em `item_old`, possibilitando a comparação dos dados antigos com os novos dados.